### PR TITLE
- Update default `TlsClientIdentifier` to `chrome_133`.

### DIFF
--- a/TlsClientWrapperSharp.Cli/Program.cs
+++ b/TlsClientWrapperSharp.Cli/Program.cs
@@ -1,6 +1,9 @@
 ﻿using TlsClientWrapperSharp.Handlers;
 
-var tlsClientHandler = new TlsClientHandler();
+var tlsClientHandler = new TlsClientHandler
+{
+    TlsClientIdentifier = "chrome_133"
+};
 
 var httpClient = new HttpClient(tlsClientHandler);
 

--- a/TlsClientWrapperSharp/Handlers/TlsClientHandler.cs
+++ b/TlsClientWrapperSharp/Handlers/TlsClientHandler.cs
@@ -29,7 +29,7 @@ namespace TlsClientWrapperSharp.Handlers
         /// <summary>
         /// Gets or sets the TLS client identifier.
         /// </summary>
-        public string TlsClientIdentifier { get; set; } = "chrome_124";
+        public string TlsClientIdentifier { get; set; } = "chrome_133";
 
         /// <summary>
         /// Sends an HTTP request asynchronously using the custom TLS client.

--- a/TlsClientWrapperSharp/Services/TlsClientWrapper.cs
+++ b/TlsClientWrapperSharp/Services/TlsClientWrapper.cs
@@ -5,13 +5,15 @@ namespace TlsClientWrapperSharp.Services;
 
 public partial class TlsClientWrapper
 {
+    private const string DllPath = "DLLs/tls-client-windows-64-1.11.2.dll";
+    
     /// <summary>
     ///     Imports the 'request' function from the TLS client DLL.
     /// </summary>
     /// <param name="requestPayload">The request payload as a byte array.</param>
     /// <param name="sessionId">The session ID.</param>
     /// <returns>A pointer to the response data.</returns>
-    [LibraryImport("./DLLs/tls-client-windows-64-1.7.8.dll", EntryPoint = "request")]
+    [LibraryImport(DllPath, EntryPoint = "request")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
     private static partial IntPtr Request([In] byte[] requestPayload,
         [MarshalAs(UnmanagedType.LPWStr)] string sessionId);
@@ -20,7 +22,7 @@ public partial class TlsClientWrapper
     ///     Imports the 'freeMemory' function from the TLS client DLL.
     /// </summary>
     /// <param name="sessionId">The session ID.</param>
-    [LibraryImport("./DLLs/tls-client-windows-64-1.7.8.dll", EntryPoint = "freeMemory")]
+    [LibraryImport(DllPath, EntryPoint = "freeMemory")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
     private static partial void FreeMemory([In] byte[] sessionId);
 

--- a/TlsClientWrapperSharp/TlsClientWrapperSharp.csproj
+++ b/TlsClientWrapperSharp/TlsClientWrapperSharp.csproj
@@ -20,4 +20,11 @@
       <Folder Include="Utils\" />
     </ItemGroup>
 
+    <ItemGroup>
+      <None Include="DLLs\**\*">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>DLLs\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      </None>
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- Replace hardcoded DLL paths with a constant and update to `tls-client-windows-64-1.11.2.dll`.
- Configure DLLs for output directory in the project file.